### PR TITLE
fix: update the bugs URL to point to this repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "oclif-plugin"
   ],
   "homepage": "https://github.com/twilio-labs/plugin-flex",
-  "bugs": "https://github.com/twilio/twilio-cli/issues",
+  "bugs": "https://github.com/twilio-labs/plugin-flex/issues",
   "repository": {
     "type": "git",
     "url": "https://github.com/twilio-labs/plugin-flex.git"


### PR DESCRIPTION
The `BaseCommand` in `twilio/cli-core` will soon be updated to use this URL to instruct users where to open issues when handling uncaught exceptions

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
